### PR TITLE
BF: removed 1/(4*pi) factor for fod computation

### DIFF
--- a/phantomas/mr_simul/fod.py
+++ b/phantomas/mr_simul/fod.py
@@ -105,11 +105,13 @@ def compute_fod(fod_samples, fod_weights, dirs=None, kappa=30, sh=False,
     nb_samples = fod_samples.shape[0]
     nb_dirs = dirs.shape[0]
     fod = np.zeros(nb_dirs)
-    c = kappa / (4 * np.pi * (np.exp(kappa) - 1))
+    # c = kappa / (4 * np.pi * (np.exp(kappa) - 1))
+    c = (np.exp(kappa) - 1) / kappa
     for i in range(nb_samples):
         dot_prods = np.dot(dirs, fod_samples[i])
         fod += np.exp(kappa * np.abs(dot_prods)) * fod_weights[i]
-    fod *= c
+    # fod *= c
+    fod /= c
     if not sh:
         return fod
     np.clip(dirs, -1, 1, dirs)


### PR DESCRIPTION
This fixes the problem: dwis look good, fODF can be computed from them and the speed is fine. 
I guess the problem is the same (1/(4 \* np.pi)) in compute_fod_sh.

The 1/(4 \* np.pi) makes the diffusion value very low compare to the b0 value and i guess this makes the fODF computation (dipy) fails. 

What should be done?
