### PR TITLE
[ENH] Replace distutils with setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ develop-eggs
 lib
 lib64
 __pycache__
+.eggs/
 
 # Installer logs
 pip-log.txt

--- a/phantomas/__init__.py
+++ b/phantomas/__init__.py
@@ -8,9 +8,22 @@ evaluation of methods in acquisition, signal and image processing, local
 reconstruction and fiber tracking in diffusion MRI. Phantomas is released
 under the terms of the revised BSD license. You should have received a copy
 of the license together with the software, please refer to the file
-``LICENSE``.  
+``LICENSE``.
 
 """
+from __future__ import absolute_import
+from .info import (
+    __version__,
+    __author__,
+    __email__,
+    __maintainer__,
+    __copyright__,
+    __credits__,
+    __license__,
+    __status__,
+    __description__,
+    __longdesc__
+)
 
 __all__ = ['geometry', 'mr_simul', 'utils', 'visu']
-__version__ = '0.1.dev'
+

--- a/phantomas/geometry/fiber.py
+++ b/phantomas/geometry/fiber.py
@@ -5,7 +5,10 @@ cortical areas. Currently, the only supported shape for the "cortical surface"
 is a sphere.
 """
 import numpy as np
-from scipy.interpolate import PiecewisePolynomial
+try:
+    from scipy.interpolate import PiecewisePolynomial
+except ImportError:
+    from scipy.interpolate import PPoly as PiecewisePolynomial
 
 
 class FiberSource:

--- a/phantomas/info.py
+++ b/phantomas/info.py
@@ -45,7 +45,7 @@ REQUIRES = [
     'cython',
     'nibabel',
     'numpy',
-    'scikits.sparse',
+    'scikit-sparse',
     'scipy',
     'wsgiref',
 ]
@@ -54,7 +54,8 @@ REQUIRES = [
 SETUP_REQUIRES = [
     'setuptools>=18.0',
     'numpy',
-    'cython',
+    'cython'
+    'scikit-sparse',
 ]
 
 # Dependencies to be fetched from urls (e.g. github repos)

--- a/phantomas/info.py
+++ b/phantomas/info.py
@@ -68,6 +68,7 @@ TESTS_REQUIRES = []
 # For now, only documentation is enabled. Install with pip install -e .[doc]
 EXTRA_REQUIRES = {
     'doc': ['sphinx'],
+    'viz': ['matplotlib', 'mayavi'], # mayavi to provide vtk
     # 'tests': TESTS_REQUIRES,
 }
 

--- a/phantomas/info.py
+++ b/phantomas/info.py
@@ -54,7 +54,7 @@ REQUIRES = [
 SETUP_REQUIRES = [
     'setuptools>=18.0',
     'numpy',
-    'cython'
+    'cython',
     'scikit-sparse',
 ]
 

--- a/phantomas/info.py
+++ b/phantomas/info.py
@@ -40,6 +40,7 @@ CLASSIFIERS = [
 DOWNLOAD_URL = 'https://github.com/ecaruyer/phantomas'
 URL = 'http://www.emmanuelcaruyer.com/{}'.format(__packagename__)
 
+# Dependencies of phantomas
 REQUIRES = [
     'cython',
     'nibabel',
@@ -49,23 +50,26 @@ REQUIRES = [
     'wsgiref',
 ]
 
+# Required before running setup()
 SETUP_REQUIRES = [
     'setuptools>=18.0',
     'numpy',
     'cython',
 ]
 
-LINKS_REQUIRES = [
-    'git+https://github.com/oesteban/phantomas.git#egg=phantomas',
-    'git+https://github.com/oesteban/nipype.git#egg=nipype',
-]
+# Dependencies to be fethed from urls (e.g. github repos)
+LINKS_REQUIRES = []
 
+# Dependencies to install for testing (e.g. nose or pytest)
 TESTS_REQUIRES = []
 
+# Dependencies to install for extra features
+# For now, only documentation is enabled. Install with pip install -e .[doc]
 EXTRA_REQUIRES = {
     'doc': ['sphinx'],
     # 'tests': TESTS_REQUIRES,
 }
 
 # Enable a handle to install all extra dependencies at once
+# with pip install -e .[all]
 EXTRA_REQUIRES['all'] = [val for _, val in list(EXTRA_REQUIRES.items())]

--- a/phantomas/info.py
+++ b/phantomas/info.py
@@ -57,7 +57,7 @@ SETUP_REQUIRES = [
     'cython',
 ]
 
-# Dependencies to be fethed from urls (e.g. github repos)
+# Dependencies to be fetched from urls (e.g. github repos)
 LINKS_REQUIRES = []
 
 # Dependencies to install for testing (e.g. nose or pytest)

--- a/phantomas/info.py
+++ b/phantomas/info.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+"""
+Base module variables
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+from datetime import datetime
+
+__packagename__ = 'phantomas'
+__version__ = '0.1.dev'
+__author__ = 'Emmanuel Caruyer'
+__credits__ = ['Emmanuel Caruyer']
+__license__ = '3-clause BSD'
+__maintainer__ = 'Emmanuel Caruyer'
+__email__ = 'caruyer@gmail.com'
+__status__ = 'Prototype'
+__copyright__ = 'Copyright {}, {}'.format(datetime.now().year, __author__)
+
+__description__ = """A software phantom generation tool for diffusion MRI."""
+__longdesc__ = """\
+*Phantomas* is an open-source software library for the creation of *realistic \
+phantoms* in *diffusion MRI*. This is intented as a tool for the quantitative \
+evaluation of methods in acquisition, signal and image processing, local \
+reconstruction and fiber tracking in diffusion MRI. Phantomas is released \
+under the terms of the revised BSD license. You should have received a copy \
+of the license together with the software, please refer to the file \
+``LICENSE``.
+"""
+
+CLASSIFIERS = [
+    'Development Status :: 4 - Beta',
+    'Intended Audience :: Science/Research',
+    'Topic :: Scientific/Engineering :: Image Recognition',
+    'License :: OSI Approved :: BSD License',
+    'Programming Language :: Python :: 2.7',
+]
+
+DOWNLOAD_URL = 'https://github.com/ecaruyer/phantomas'
+URL = 'http://www.emmanuelcaruyer.com/{}'.format(__packagename__)
+
+REQUIRES = [
+    'cython',
+    'nibabel',
+    'numpy',
+    'scikits.sparse',
+    'scipy',
+    'wsgiref',
+]
+
+SETUP_REQUIRES = [
+    'setuptools>=18.0',
+    'numpy',
+    'cython',
+]
+
+LINKS_REQUIRES = [
+    'git+https://github.com/oesteban/phantomas.git#egg=phantomas',
+    'git+https://github.com/oesteban/nipype.git#egg=nipype',
+]
+
+TESTS_REQUIRES = []
+
+EXTRA_REQUIRES = {
+    'doc': ['sphinx'],
+    # 'tests': TESTS_REQUIRES,
+}
+
+# Enable a handle to install all extra dependencies at once
+EXTRA_REQUIRES['all'] = [val for _, val in list(EXTRA_REQUIRES.items())]

--- a/phantomas/mr_simul/image_formation.py
+++ b/phantomas/mr_simul/image_formation.py
@@ -12,7 +12,10 @@ References
 """
 import numpy as np
 import scipy.sparse as scisp
-from scikits.sparse.cholmod import cholesky
+try:
+    from scikits.sparse.cholmod import cholesky
+except ImportError:
+    from sksparse.cholmod import cholesky
 
 
 def _random_correlated_image(mean, sigma, image_shape, alpha=0.3, rng=None):
@@ -109,8 +112,8 @@ def get_tissue_physical_parameters(tissue_type):
         proton density
 
     """
-    return (_physical_parameters[tissue_type]['t1']['mean'], 
-            _physical_parameters[tissue_type]['t2']['mean'], 
+    return (_physical_parameters[tissue_type]['t1']['mean'],
+            _physical_parameters[tissue_type]['t2']['mean'],
             _physical_parameters[tissue_type]['rho'])
 
 def relaxation_time_images(image_shape, tissue_type, rng=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-Cython==0.23.4
-Phantomas==0.1.dev
-argparse==1.2.1
-nibabel==2.0.1
-numpy==1.10.1
-scikits.sparse==0.2
-scipy==0.16.1
-wsgiref==0.1.2
+cython
+numpy
+argparse
+scipy
+nibabel
+scikit-sparse
+wsgiref

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
-Cython==0.23.4
-Phantomas==0.1.dev
-argparse==1.2.1
-nibabel==2.0.1
-numpy==1.10.1
-scikits.sparse==0.2
-scipy==0.16.1
-wsgiref==0.1.2
+cython
+nibabel
+numpy
+scikits.sparse
+scipy
+wsgiref

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
-cython
-nibabel
-numpy
-scikits.sparse
-scipy
-wsgiref
+Cython==0.23.4
+Phantomas==0.1.dev
+argparse==1.2.1
+nibabel==2.0.1
+numpy==1.10.1
+scikits.sparse==0.2
+scipy==0.16.1
+wsgiref==0.1.2

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,8 @@ import sys
 
 def main():
     from glob import glob
-    from setuptools import setup, find_packages
+    from setuptools import setup, find_packages, Extension
     from setuptools.extension import Extension
-
-    from Cython.Distutils import build_ext
-    from Cython.Build import cythonize
     import numpy as np
 
     REQ_LINKS = []
@@ -40,13 +37,13 @@ def main():
           author='Emmanuel Caruyer',
           author_email='caruyer@gmail.com',
           url='http://www.emmanuelcaruyer.com/phantomas/',
+          setup_requires=['setuptools>=18.0', 'numpy', 'cython'],
           install_requires=REQUIREMENTS,
           dependency_links=REQ_LINKS,
           packages=find_packages(),
           package_data={'phantomas.mr_simul': ["spherical_21_design.txt"]},
           scripts=glob('scripts/*'),
-          # cmdclass={'build_ext': build_ext},
-          ext_modules=cythonize(extensions),
+          ext_modules=extensions,
     )
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -25,13 +25,13 @@ def main():
     if REQUIREMENTS is None:
         REQUIREMENTS = []
 
-    extensions = [
-        Extension("phantomas.mr_simul.fast_volume_fraction",
-                  ["phantomas/mr_simul/fast_volume_fraction.pyx",
-                   "phantomas/mr_simul/c_fast_volume_fraction.c"],
-                  include_dirs=[np.get_include(), "/usr/local/include/"],
-                  library_dirs=["/usr/lib/"],
-                  libraries=["gsl", "gslcblas"]),
+    extensions = [Extension(
+            "phantomas.mr_simul.fast_volume_fraction",
+            ["phantomas/mr_simul/fast_volume_fraction.pyx",
+            "phantomas/mr_simul/c_fast_volume_fraction.c"],
+            include_dirs=[np.get_include(), "/usr/local/include/"],
+            library_dirs=["/usr/lib/"],
+            libraries=["gsl", "gslcblas"]),
     ]
 
     setup(name='phantomas',
@@ -40,12 +40,14 @@ def main():
           author='Emmanuel Caruyer',
           author_email='caruyer@gmail.com',
           url='http://www.emmanuelcaruyer.com/phantomas/',
+          install_requires=REQUIREMENTS,
+          dependency_links=REQ_LINKS,
           packages=find_packages(),
           package_data={'phantomas.mr_simul': ["spherical_21_design.txt"]},
           scripts=glob('scripts/*'),
           # cmdclass={'build_ext': build_ext},
           ext_modules=cythonize(extensions),
-          )
+    )
 
 if __name__ == '__main__':
     LOCAL_PATH = os.path.dirname(os.path.abspath(sys.argv[0]))

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,30 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os
-import sys
+PACKAGE_NAME = 'phantomas'
 
 def main():
+    """ Install entry-point """
+    from os import path as op
     from glob import glob
-    from setuptools import setup, find_packages, Extension
+    from inspect import getfile, currentframe
+    from setuptools import setup, find_packages
     from setuptools.extension import Extension
+    from io import open  # pylint: disable=W0622
     import numpy as np
 
-    REQ_LINKS = []
-    with open('requirements.txt', 'r') as rfile:
-        REQUIREMENTS = [line.strip() for line in rfile.readlines()]
+    this_path = op.dirname(op.abspath(getfile(currentframe())))
 
-    for i, req in enumerate(REQUIREMENTS):
-        if req.startswith('-e'):
-            REQUIREMENTS[i] = req.split('=')[1]
-            REQ_LINKS.append(req.split()[1])
+    # Python 3: use a locals dictionary
+    # http://stackoverflow.com/a/1463370/6820620
+    ldict = locals()
 
-    if REQUIREMENTS is None:
-        REQUIREMENTS = []
+    # Get version and release info, which is all stored in phantomas/info.py
+    module_file = op.join(this_path, PACKAGE_NAME, 'info.py')
+    with open(module_file) as infofile:
+        pythoncode = [line for line in infofile.readlines() if not line.strip().startswith('#')]
+        exec('\n'.join(pythoncode), globals(), ldict)
+
 
     extensions = [Extension(
             "phantomas.mr_simul.fast_volume_fraction",
@@ -31,25 +35,33 @@ def main():
             libraries=["gsl", "gslcblas"]),
     ]
 
-    setup(name='phantomas',
-          description='A software phantom generation tool for diffusion MRI.',
-          version='0.1.dev',
-          author='Emmanuel Caruyer',
-          author_email='caruyer@gmail.com',
-          url='http://www.emmanuelcaruyer.com/phantomas/',
-          setup_requires=['setuptools>=18.0', 'numpy', 'cython'],
-          install_requires=REQUIREMENTS,
-          dependency_links=REQ_LINKS,
-          packages=find_packages(),
-          package_data={'phantomas.mr_simul': ["spherical_21_design.txt"]},
-          scripts=glob('scripts/*'),
-          ext_modules=extensions,
+    setup(
+        name=PACKAGE_NAME,
+        version=ldict['__version__'],
+        description=ldict['__description__'],
+        long_description=ldict['__longdesc__'],
+        author=ldict['__author__'],
+        author_email=ldict['__email__'],
+        maintainer=ldict['__maintainer__'],
+        maintainer_email=ldict['__email__'],
+        license=ldict['__license__'],
+        url=ldict['URL'],
+        download_url=ldict['DOWNLOAD_URL'],
+        classifiers=ldict['CLASSIFIERS'],
+        packages=find_packages(exclude=['build', 'doc', 'examples', 'scripts']),
+        package_data={'phantomas.mr_simul': ["spherical_21_design.txt"]},
+        scripts=glob('scripts/*'),
+        ext_modules=extensions,
+        zip_safe=False,
+        # Dependencies handling
+        setup_requires=ldict['SETUP_REQUIRES'],
+        install_requires=ldict['REQUIRES'],
+        dependency_links=ldict['LINKS_REQUIRES'],
+        tests_require=ldict['TESTS_REQUIRES'],
+        extras_require=ldict['EXTRA_REQUIRES'],
     )
 
-if __name__ == '__main__':
-    LOCAL_PATH = os.path.dirname(os.path.abspath(sys.argv[0]))
-    os.chdir(LOCAL_PATH)
-    sys.path.insert(0, LOCAL_PATH)
 
+if __name__ == '__main__':
     main()
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def main():
                   libraries=["gsl", "gslcblas"]),
     ]
 
-    setup(name='Phantomas',
+    setup(name='phantomas',
           description='A software phantom generation tool for diffusion MRI.',
           version='0.1.dev',
           author='Emmanuel Caruyer',

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,55 @@
-from distutils.core import setup
-from distutils.extension import Extension
-from Cython.Distutils import build_ext
-from Cython.Build import cythonize
-import numpy as np
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 import os
+import sys
 
-extensions = [
-    Extension("phantomas.mr_simul.fast_volume_fraction",
-              ["phantomas/mr_simul/fast_volume_fraction.pyx",
-               "phantomas/mr_simul/c_fast_volume_fraction.c"],
-              include_dirs=[np.get_include(), "/usr/local/include/"],
-              library_dirs=["/usr/lib/"],
-              libraries=["gsl", "gslcblas"]),
-]
+def main():
+    from glob import glob
+    from setuptools import setup, find_packages
+    from setuptools.extension import Extension
 
-setup(name='Phantomas',
-      description='A software phantom generation tool for diffusion MRI.',
-      version='0.1.dev',
-      author='Emmanuel Caruyer',
-      author_email='caruyer@gmail.com',
-      url='http://www.emmanuelcaruyer.com/phantomas/',
-      packages=['phantomas',
-                'phantomas.geometry',
-                'phantomas.mr_simul',
-                'phantomas.utils',
-                'phantomas.visu'],
-      package_data={'phantomas.mr_simul': ["spherical_21_design.txt"]},
-      scripts=[os.path.join('scripts', 'phantomas_struct'),
-               os.path.join('scripts', 'phantomas_dwis'),
-               os.path.join('scripts', 'phantomas_rois'),
-               os.path.join('scripts', 'phantomas_masks'),
-               os.path.join('scripts', 'phantomas_view')],
-      # cmdclass={'build_ext': build_ext},
-      ext_modules=cythonize(extensions),
-      )
+    from Cython.Distutils import build_ext
+    from Cython.Build import cythonize
+    import numpy as np
+
+    REQ_LINKS = []
+    with open('requirements.txt', 'r') as rfile:
+        REQUIREMENTS = [line.strip() for line in rfile.readlines()]
+
+    for i, req in enumerate(REQUIREMENTS):
+        if req.startswith('-e'):
+            REQUIREMENTS[i] = req.split('=')[1]
+            REQ_LINKS.append(req.split()[1])
+
+    if REQUIREMENTS is None:
+        REQUIREMENTS = []
+
+    extensions = [
+        Extension("phantomas.mr_simul.fast_volume_fraction",
+                  ["phantomas/mr_simul/fast_volume_fraction.pyx",
+                   "phantomas/mr_simul/c_fast_volume_fraction.c"],
+                  include_dirs=[np.get_include(), "/usr/local/include/"],
+                  library_dirs=["/usr/lib/"],
+                  libraries=["gsl", "gslcblas"]),
+    ]
+
+    setup(name='Phantomas',
+          description='A software phantom generation tool for diffusion MRI.',
+          version='0.1.dev',
+          author='Emmanuel Caruyer',
+          author_email='caruyer@gmail.com',
+          url='http://www.emmanuelcaruyer.com/phantomas/',
+          packages=find_packages(),
+          package_data={'phantomas.mr_simul': ["spherical_21_design.txt"]},
+          scripts=glob('scripts/*'),
+          # cmdclass={'build_ext': build_ext},
+          ext_modules=cythonize(extensions),
+          )
+
+if __name__ == '__main__':
+    LOCAL_PATH = os.path.dirname(os.path.abspath(sys.argv[0]))
+    os.chdir(LOCAL_PATH)
+    sys.path.insert(0, LOCAL_PATH)
+
+    main()


### PR DESCRIPTION
Replacing distutils by setuptools will give some flexibility and make it easier the distribution of phantomas through pypi (and thus, make phantomas pip-installable)

Added the `phantomas/info.py` where all the distribution variables and requirements lists are added.

With this PR, installation will smoothly work only using:

```
git clone ...
python setup.py install
```

Additionally, everything is in place to register and upload to pypi (although there is already a phantomas package out there, maybe worth asking for the name). When registered, installation will be as easy as:

```
pip install <package-name>
```

Some minor changes are:
- Removed `Phantomas` from `requirements.txt`. If such behavior was intended, please add a line with the content `-e .[all]` at the bottom of the `requirements.txt` file.
- Removed versions from requirements, since they are no longer necessary.
- Updated the name `scikits.sparse` to `scikit-sparse` (which is, apparently the current name of the package in Pypi and conda-forge). This change solves the problem in the README file of `scikits/sparse/cholmod.c:245:33: fatal error: suitesparse/cholmod.h: No such file or directory` if `scikits.sparse` is installed with pypi or conda, since the installation did not correctly detect that the package was already installed.
- Added more robust imports to `PiecewisePolynomial` from `scipy.interpolate` and `cholesky` from scikit-sparse.
- Added extra dependencies (matlab, vtk). These can be installed with:

```
pip install -e .[viz]
```

or

```
pip install phantomas[viz]
```

if it was in pypi.
